### PR TITLE
Update Magic Eden 'Connect Wallet' text

### DIFF
--- a/magiceden.py
+++ b/magiceden.py
@@ -58,9 +58,9 @@ def mint(values, isWindows):
     def selectWallet():
         print("Status - Selecting wallet on ME")
         WebDriverWait(driver, 60).until(EC.presence_of_element_located(
-            (By.XPATH, "//button[contains(text(), 'Select Wallet')]")))
+            (By.XPATH, "//button[contains(text(), 'Connect Wallet')]")))
         select_wallet = driver.find_element(
-            By.XPATH, "//button[contains(text(), 'Select Wallet')]")
+            By.XPATH, "//button[contains(text(), 'Connect Wallet')]")
         select_wallet.click()
 
         WebDriverWait(driver, 60).until(EC.presence_of_element_located(


### PR DESCRIPTION
Seems Magic Eden has already replaced the old 'Select Wallet' keyword with the 'Connect Wallet' keyword now. Update the XPath selector in order to make this code working again. 
![image](https://user-images.githubusercontent.com/25129943/177033155-c6746d58-3861-4b64-950e-6c54d78e239c.png)
